### PR TITLE
Emoji picker: Fix word breaking

### DIFF
--- a/emojipicker/styles/all/template/event/overall_footer_body_after.html
+++ b/emojipicker/styles/all/template/event/overall_footer_body_after.html
@@ -246,7 +246,10 @@
 				// Keep the original height, break long words
 				$('div.emojionearea-editor').css({
 					'min-height': $emojiPicker.css('height'),
-					'word-break': 'break-all'
+					'word-break': 'break-word',
+					'-webkit-hyphens': 'auto',
+					'-ms-hyphens': 'auto',
+					'hyphens': 'auto'
 				});
 
 				// Trick for FireFox incorrect caret position on the contenteditable elements: https://bugzilla.mozilla.org/show_bug.cgi?id=904846


### PR DESCRIPTION
Please use `break-word` to avo
id unnecessary breaks int the m
iddle of words. ;)

Also introduces hyphenation.